### PR TITLE
WCM-1463 Fix the label missing issue when there are more than on labels have a same name

### DIFF
--- a/src/charts/js/CategoryAxis.js
+++ b/src/charts/js/CategoryAxis.js
@@ -86,10 +86,16 @@ Y.CategoryAxis = Y.Base.create("categoryAxis", Y.Axis, [Y.CategoryImpl], {
             data = this.get("data"),
             offset = edgeOffset;
         dataValues = dataValues || data;
+        var indexMap = new Map();
         for(i = 0; i < count; i = i + 1)
         {
             labelValue = dataValues[i];
             labelIndex = Y.Array.indexOf(data, labelValue);
+            if(indexMap.has(labelValue))
+            {
+            	labelIndex = Y.Array.indexOf(data, labelValue, indexMap.get(labelValue)+1);
+            }
+            indexMap.set(labelValue, labelIndex);
             if(Y_Lang.isNumber(labelIndex) && labelIndex > -1)
             {
                 point = {};


### PR DESCRIPTION
Hi @hhuijser 

The issue is that when drawing a chart in YUI, It seems the developer didn't consider that there will be more than one labels have a same name. So, When positioning the labels, those labels with a same name will have a same location. Then it seems like some labels are missing.

I found the reason which caused the issue is that the logic to position the label is searching index by the label's name. Like the follow code:
labelIndex = Y.Array.indexOf(data, labelValue);

My fix is create a map to store the index of element when it show up last time, then next time if it show up again, it will start searching from the next index of the one we stored in map.

Thanks,
Seiphon